### PR TITLE
Return error tuple when parsing fails

### DIFF
--- a/benchmarks/parse.exs
+++ b/benchmarks/parse.exs
@@ -24,7 +24,7 @@
 # uspca            380.75 K        2.63 μs   ±576.13%        2.21 μs        4.25 μs
 # tcf & uspv1       36.89 K       27.11 μs    ±19.34%       25.26 μs       37.67 μs
 #
-# Comparison: 
+# Comparison:
 # header          1003.31 K
 # uspca            380.75 K - 2.64x slower +1.63 μs
 # tcf & uspv1       36.89 K - 27.20x slower +26.11 μs
@@ -35,11 +35,15 @@ tcf_uspv1 =
 header = "DBACNYA"
 uspca = "DBABBgA~xlgWEYCZAA"
 
+broken_input =
+  "DBABjw~CPzHq4APzHq4ABEACBENAuCMAP-AAP-AAAmDAkAAUADQAJYAXQAzACCAEUAMoAaYA54CSgJMAT8AzQBnQDPgGvASoAn8BbwC4QF7gL_AYOAzABo4DagG4gONAeIA-QCAgEbgI_gSlAlUBMEEwYEgACgAaABLAC6AGYAQQAigBlADTAHPASUBJgCfgGaAM6AZ8A14CVAE_gLeAXCAvcBf4DBwGYANHAbUA3EBxoDxAHyAQEAjcBH8CUoEqgJggA.YAAAAAAAAAA~1---"
+
 Benchee.run(
   %{
     "header" => fn -> Gpp.parse(header) end,
     "tcf & uspv1" => fn -> Gpp.parse(tcf_uspv1) end,
-    "uspca" => fn -> Gpp.parse(uspca) end
+    "uspca" => fn -> Gpp.parse(uspca) end,
+    "broken input" => fn -> Gpp.parse(broken_input) end
   }
   # parallel: System.schedulers_online()
 )

--- a/lib/gpp.ex
+++ b/lib/gpp.ex
@@ -73,9 +73,6 @@ defmodule Gpp do
          {:ok, header_bits} <- BitUtil.url_base64_to_bits(header),
          {:ok, gpp, section_range} <- parse_header(header_bits) do
       parse_sections(gpp, section_range, sections)
-    else
-      {:error, _error} = error ->
-        error
     end
   end
 
@@ -206,9 +203,6 @@ defmodule Gpp do
             with {:ok, parser} <- parser(id),
                  {:ok, parsed} <- parser.(value) do
               [%{parsed | section_id: id} | acc]
-            else
-              {:error, _error} = error ->
-                error
             end
         end
       end)

--- a/test/gpp/sections/tcf_test.exs
+++ b/test/gpp/sections/tcf_test.exs
@@ -8,8 +8,7 @@ defmodule Gpp.Sections.TcfTest do
       input =
         "BOtn-dKO4E4lPAKAkBITDW-AAAAyN7_______9_-____9uz_Ov_v_f__33e8__9v_l_7_-___u_-23d4u_1vf99yfmx-7etr3tp_47ues2_Xurf_71__3z3_9pxP78E89r7335EQ_v-_t-b7BCHN_Y2v-8K96lPKACE"
 
-      assert {:ok, %Tcf{version: 1, vendor_consents: consents}} =
-               Tcf.parse(input)
+      assert {:ok, %Tcf{version: 1, vendor_consents: consents}} = Tcf.parse(input)
 
       assert length(consents) == 605
       assert 737 in consents
@@ -21,8 +20,7 @@ defmodule Gpp.Sections.TcfTest do
       input =
         "CGL23UdMFJzvuA9ACCENAXCEAC0AAGrAAA5YA5ht7-_d_7_vd-f-nrf4_4A4hM4JCKoK4YhmAqABgAEgAA.IFut_a83_Ma_t-_SvB3v4-IAeIAACAIgSAAQAIAgEQACEABAAAgAQFAEAIAAAGBAAgAAAAQAIFAAMCQAAgAAQiRAEQAAAAANAAIAAggAIYQFAAARmggBC3ZCYzU2yIA.QFulWfTw4obx_Z2zUj6XkNIAeIAACAIgSAAQAIAgEQACEABAAAgAQFAEAIAAAGBAAgAAAAQAIFAAMCQAAgAAQiRAEQAAAAANAAIAAggAIYQFAAARmggBC3ZCYzU2yIA"
 
-      assert {:ok, %Tcf{version: 2, vendor_consents: consents} = res} =
-               Tcf.parse(input)
+      assert {:ok, %Tcf{version: 2, vendor_consents: consents} = res} = Tcf.parse(input)
 
       assert length(consents) == 91
       assert 111 in res.vendor_consents
@@ -32,16 +30,14 @@ defmodule Gpp.Sections.TcfTest do
       input =
         "CO4D9fZO4D9fZAGABCENAyCsAP_AAE_AABaYGGQHwAAwAKAAsABoAGQAOAAgABUADIAGgAOoAegB8AEUAJgAUAAwgBoAEJAI4AkABLACiAFaAMsAeAA_QCAAEHAIwAWYBJ4C8wGGAIPAHADQAIQARwAywB4AEAAIOASMgDAAqACYAI4AZYBGAF5iIAYAKgBlgEYCQDQAFgAZAA4ACAAFQANAAfABMAEsAMsAfoBGAF5hoAYAKgBlgEYFQBgAVABMAEcAMsAjAC8x0AwABYAGQAOAAgABUADQAHwATABLAD9AIwAvMhAGAAWABkAFQATABHAEYJQBgAFgAZAA4AEwAjAC8ykAoABYAGQAOAAgABUADQAJgA_QCMALzAAA.YAAAAAAAAAAA"
 
-      assert {:ok, %Tcf{version: 2, vendor_consents: consents} = res} =
-               Tcf.parse(input)
+      assert {:ok, %Tcf{version: 2, vendor_consents: consents} = res} = Tcf.parse(input)
 
       assert length(consents) == 35
       assert 143 in res.vendor_consents
     end
 
     test "returns parseError for invalid input" do
-      assert {:error, %Tcf.DecodeError{}} =
-               Tcf.parse("WAT")
+      assert {:error, %Tcf.DecodeError{}} = Tcf.parse("WAT")
     end
 
     test "error for invalid input" do

--- a/test/gpp_test.exs
+++ b/test/gpp_test.exs
@@ -137,7 +137,14 @@ defmodule GppTest do
   end
 
   test "should handle error gracefully in parse/1" do
-    input = "DBABDA~"
-    assert {:error, _reason} = Gpp.parse(input)
+    inputs = [
+      "DBABjw~CPzHq4APzHq4ABEACBENAuCMAP-AAP-AAAmDAkAAUADQAJYAXQAzACCAEUAMoAaYA54CSgJMAT8AzQBnQDPgGvASoAn8BbwC4QF7gL_AYOAzABo4DagG4gONAeIA-QCAgEbgI_gSlAlUBMEEwYEgACgAaABLAC6AGYAQQAigBlADTAHPASUBJgCfgGaAM6AZ8A14CVAE_gLeAXCAvcBf4DBwGYANHAbUA3EBxoDxAHyAQEAjcBH8CUoEqgJggA.YAAAAAAAAAA~1---",
+      "DBABDA~",
+      "DBABDA~0"
+    ]
+
+    Enum.each(inputs, fn input ->
+      assert {:error, _reason} = Gpp.parse(input)
+    end)
   end
 end

--- a/test/gpp_test.exs
+++ b/test/gpp_test.exs
@@ -135,4 +135,9 @@ defmodule GppTest do
     input = "dbaa"
     assert {:error, %Gpp.InvalidType{}} = Gpp.parse(input)
   end
+
+  test "should handle error gracefully in parse/1" do
+    input = "DBABDA~"
+    assert {:error, _reason} = Gpp.parse(input)
+  end
 end


### PR DESCRIPTION
We discovered an issue in the gpp library, in certain cases an error is left unhandled due to malformed gpp input, this crashes our program and we would rather handle it gracefully and return an error tuple. 

You can recreate this issue with the follow gpp string as input: `DBABDA~`

```
iex(1)> input = "DBABDA~"
"DBABDA~"
iex(2)> Gpp.parse(input)
{:ok,
 %Gpp{
   type: 3,
   version: 1,
   section_ids: [5],
   sections: [
     %Gpp.BitUtil.InvalidData{message: "expected atleast 3 bits, got: []"}
   ]
 }}
```

In this pr we would instead return an `:error` tuple instead of the `:ok` so that when calling this api we know that an error has occurred.