### PR TITLE
Retrieve cmp_id from tcf string

### DIFF
--- a/lib/gpp/sections/tcf.ex
+++ b/lib/gpp/sections/tcf.ex
@@ -15,7 +15,8 @@ defmodule Gpp.Sections.Tcf do
     :section_id,
     :version,
     :vendor_consents,
-    :value
+    :value,
+    :cmp_id
   ]
 
   @impl Gpp.Section

--- a/lib/gpp/sections/tcfv1/segment.ex
+++ b/lib/gpp/sections/tcfv1/segment.ex
@@ -2,9 +2,10 @@ defmodule Gpp.Sections.Tcfv1.Segment do
   @moduledoc false
   alias Gpp.Sections.Tcf
   alias Gpp.Sections.Tcf.{VendorList, DecodeError}
+  alias Gpp.BitUtil
 
   # Full field list with lengths.
-  # We are only interested in vendor_consents, so we skip straight to that field.
+  # We are only interested in cmp_id & vendor_consents, so we skip the rest of the fields
   #
   # :created, 36
   # :last_updated, 36
@@ -15,13 +16,16 @@ defmodule Gpp.Sections.Tcfv1.Segment do
   # :vendor_list_version, 12
   # :purpose_consents, 24
   # :vendor_consents, 16
-  @skip_bits 36 + 36 + 12 + 12 + 6 + 12 + 12 + 24
+  @first_skip_bits 36 + 36
+  @second_skip_bits 12 + 6 + 12 + 12 + 24
 
   def decode(full_string, :core, segment) do
-    input = Enum.drop(segment, @skip_bits)
+    input = Enum.drop(segment, @first_skip_bits)
+    {:ok, cmp_id, second_input} = BitUtil.parse_12bit_int(input)
+    vendor_list = Enum.drop(second_input, @second_skip_bits)
 
-    with {:ok, consents, _rest} <- VendorList.decode(input) do
-      {:ok, %Tcf{version: 1, value: full_string, vendor_consents: consents}}
+    with {:ok, consents, _rest} <- VendorList.decode(vendor_list) do
+      {:ok, %Tcf{version: 1, value: full_string, vendor_consents: consents, cmp_id: cmp_id}}
     end
   end
 

--- a/lib/gpp/sections/tcfv2/segment.ex
+++ b/lib/gpp/sections/tcfv2/segment.ex
@@ -2,9 +2,10 @@ defmodule Gpp.Sections.Tcfv2.Segment do
   @moduledoc false
   alias Gpp.Sections.Tcf
   alias Gpp.Sections.Tcf.{VendorList, DecodeError}
+  alias Gpp.BitUtil
 
   # Full field list with lengths.
-  # We are only interested in vendor_consents, so we skip straight to that field.
+  # We are only interested in cmp_id & vendor_consents, so we skip the rest of the fields.
   #
   # :created, 36
   # :last_updated, 36
@@ -24,13 +25,16 @@ defmodule Gpp.Sections.Tcfv2.Segment do
   # :vendor_consents, 16
   # :vendor_legitimate_interests, 12
   # :publisher_restrictions
-  @skip_bits 36 + 36 + 12 + 12 + 6 + 12 + 12 + 6 + 1 + 1 + 12 + 24 + 24 + 1 + 12
+  @first_skip_bits 36 + 36
+  @second_skip_bits 12 + 6 + 12 + 12 + 6 + 1 + 1 + 12 + 24 + 24 + 1 + 12
 
   def decode(full_string, :core, segment) do
-    input = Enum.drop(segment, @skip_bits)
+    input = Enum.drop(segment, @first_skip_bits)
+    {:ok, cmp_id, second_input} = BitUtil.parse_12bit_int(input)
+    vendor_list = Enum.drop(second_input, @second_skip_bits)
 
-    with {:ok, consents, _rest} <- VendorList.decode(input) do
-      {:ok, %Tcf{version: 2, value: full_string, vendor_consents: consents}}
+    with {:ok, consents, _rest} <- VendorList.decode(vendor_list) do
+      {:ok, %Tcf{version: 2, value: full_string, vendor_consents: consents, cmp_id: cmp_id}}
     end
   end
 

--- a/test/gpp_test.exs
+++ b/test/gpp_test.exs
@@ -12,7 +12,8 @@ defmodule GppTest do
              section_id: 2,
              vendor_consents: [],
              version: 2,
-             value: "CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA"
+             value: "CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA",
+             cmp_id: 31
            }
          ]
        }},
@@ -24,6 +25,7 @@ defmodule GppTest do
              section_id: 2,
              vendor_consents: [],
              version: 2,
+             cmp_id: 31,
              value: "CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA"
            },
            %Gpp.Sections.Uspv1{
@@ -45,7 +47,8 @@ defmodule GppTest do
               section_id: 5,
               vendor_consents: [],
               version: 2,
-              value: "CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA"
+              value: "CPXxRfAPXxRfAAfKABENB-CgAAAAAAAAAAYgAAAAAAAA",
+              cmp_id: 31
             },
             %Gpp.Sections.Uspv1{
               section_id: 6,


### PR DESCRIPTION
We want to fetch the cmp_id from the tcp string, the cmp_id is the "Consent Management Platform ID that last updated the TC String. A unique ID will be assigned to each Consent Management Platform."