### PR TITLE
Tcfca fix

### DIFF
--- a/lib/gpp/sections/tcf.ex
+++ b/lib/gpp/sections/tcf.ex
@@ -28,7 +28,7 @@ defmodule Gpp.Sections.Tcf do
       case version do
         2 -> Tcfv2.Segment.decode(input, type, rest)
         1 -> Tcfv1.Segment.decode(input, type, rest)
-        other -> {:error, %DecodeError{message: "unknown TCF EU version: #{other}"}}
+        other -> {:error, %DecodeError{message: "unknown TCF version: #{other}"}}
       end
     end
   end

--- a/lib/gpp/sections/tcfcav1.ex
+++ b/lib/gpp/sections/tcfcav1.ex
@@ -16,11 +16,9 @@ defmodule Gpp.Sections.Tcfcav1 do
     with [core_segment | _] <- String.split(input, ".", parts: 2),
          {:ok, bits} <- BitUtil.url_base64_to_bits(core_segment),
          {:ok, type, _rest} <- Tcf.segment_type(bits),
-         {:ok, version, rest} <- Tcf.version(bits) do
-      case version do
-        1 -> __MODULE__.Segment.decode(input, type, rest)
-        other -> {:error, %Tcf.DecodeError{message: "unknown TCF CA version: #{other}"}}
-      end
+         {:ok, version, rest} <- Tcf.version(bits),
+         {:ok, parsed} <- __MODULE__.Segment.decode(input, type, rest) do
+      {:ok, %{parsed | version: version}}
     end
   end
 end

--- a/lib/gpp/sections/tcfcav1.ex
+++ b/lib/gpp/sections/tcfcav1.ex
@@ -18,7 +18,7 @@ defmodule Gpp.Sections.Tcfcav1 do
          {:ok, type, _rest} <- Tcf.segment_type(bits),
          {:ok, version, rest} <- Tcf.version(bits) do
       case version do
-        2 -> __MODULE__.Segment.decode(input, type, rest)
+        1 -> __MODULE__.Segment.decode(input, type, rest)
         other -> {:error, %Tcf.DecodeError{message: "unknown TCF CA version: #{other}"}}
       end
     end

--- a/lib/gpp/sections/tcfcav1/segment.ex
+++ b/lib/gpp/sections/tcfcav1/segment.ex
@@ -27,7 +27,7 @@ defmodule Gpp.Sections.Tcfcav1.Segment do
   def decode(full_string, :core, segment) do
     with {:ok, cmp_id, consents} <-
            Segment.decode_fields(segment, @first_skip_bits, @second_skip_bits) do
-      {:ok, %Tcf{version: 2, value: full_string, vendor_consents: consents, cmp_id: cmp_id}}
+      {:ok, %Tcf{version: 1, value: full_string, vendor_consents: consents, cmp_id: cmp_id}}
     end
   end
 

--- a/test/gpp/sections/tcfcav1_test.exs
+++ b/test/gpp/sections/tcfcav1_test.exs
@@ -1,0 +1,34 @@
+defmodule Gpp.Sections.Tcfcav1Test do
+  use ExUnit.Case, async: true
+
+  alias Gpp.Sections.{Tcfcav1, Tcf}
+
+  test "example" do
+    input =
+      "BP7GiMAP7GiMAPoABABGBFCAAAAAAAAAAAXDAMAGUANMAc4A7gCAQElASYAn4BmgDOgGfANeAuEAAAAA.YAAAAAAAAAA"
+
+    consents =
+      Enum.reverse([
+        202,
+        211,
+        231,
+        238,
+        256,
+        293,
+        294,
+        319,
+        410,
+        413,
+        415,
+        431,
+        737
+      ])
+
+    assert {:ok,
+            %Tcf{
+              version: 1,
+              value: input,
+              vendor_consents: consents
+            }} == Tcfcav1.parse(input)
+  end
+end

--- a/test/gpp/sections/tcfcav1_test.exs
+++ b/test/gpp/sections/tcfcav1_test.exs
@@ -28,6 +28,60 @@ defmodule Gpp.Sections.Tcfcav1Test do
             %Tcf{
               version: 1,
               value: input,
+              cmp_id: 1000,
+              vendor_consents: consents
+            }} == Tcfcav1.parse(input)
+  end
+
+  test "allows version 2" do
+    input =
+      "CPzHq4APzHq4ABEACBENAuCMAP-AAP-AAAmDAkAAUADQAJYAXQAzACCAEUAMoAaYA54CSgJMAT8AzQBnQDPgGvASoAn8BbwC4QF7gL_AYOAzABo4DagG4gONAeIA-QCAgEbgI_gSlAlUBMEEwYEgACgAaABLAC6AGYAQQAigBlADTAHPASUBJgCfgGaAM6AZ8A14CVAE_gLeAXCAvcBf4DBwGYANHAbUA3EBxoDxAHyAQEAjcBH8CUoEqgJggA.YAAAAAAAAAA~1---"
+
+    consents = [
+      1217,
+      1194,
+      1189,
+      1151,
+      1134,
+      1028,
+      996,
+      964,
+      909,
+      881,
+      874,
+      839,
+      816,
+      775,
+      767,
+      759,
+      737,
+      734,
+      639,
+      596,
+      431,
+      415,
+      413,
+      410,
+      319,
+      294,
+      293,
+      231,
+      211,
+      202,
+      138,
+      130,
+      102,
+      93,
+      75,
+      52,
+      10
+    ]
+
+    assert {:ok,
+            %Tcf{
+              version: 2,
+              value: input,
+              cmp_id: 68,
               vendor_consents: consents
             }} == Tcfcav1.parse(input)
   end

--- a/test/gpp_test.exs
+++ b/test/gpp_test.exs
@@ -145,7 +145,24 @@ defmodule GppTest do
              version: 1
            }
          ]
-       }}
+       }},
+      {
+        "DBABDA~BP6vdoAP6vdoAPoABABGBECAAAAAAAAAAAXDABAXCAAAAAA.YAAAAAAAAAA",
+        %Gpp{
+          section_ids: [5],
+          sections: [
+            %Gpp.Sections.Tcf{
+              section_id: 5,
+              version: 1,
+              vendor_consents: [737],
+              value: "BP6vdoAP6vdoAPoABABGBECAAAAAAAAAAAXDABAXCAAAAAA.YAAAAAAAAAA",
+              cmp_id: 1000
+            }
+          ],
+          type: 3,
+          version: 1
+        }
+      }
     ]
 
     for {input, expected} <- examples do


### PR DESCRIPTION
We have encountered TCFCA segments with versions that != 1 even though that is the only version currently. For now, we will just use the same parsing logic for all TCFCA segments until there is a new version announced.